### PR TITLE
Shift more dependencies to the browser extra 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,26 @@
 language: python
 sudo: false
 python:
-  - 2.7
-  - 3.4
-  - 3.5
-  - 3.6
-  - pypy-5.4.1
-script:
-  - coverage run -m zope.testrunner --test-path=src  --auto-color --auto-progress
-
-after_success:
-  - coveralls
-notifications:
-  email: false
-
+    - 2.7
+    - 3.4
+    - 3.5
+    - 3.6
+    - pypy
+    - pypy3
+env:
+    - DEP=test
+matrix:
+  include:
+    - python: 2.7
+      env: DEP=no_such_extra
 install:
-  - pip install -U pip setuptools
-  - pip install -U coveralls coverage
-  - pip install -U -e ".[test]"
-
-
+    - pip install -U pip setuptools
+    - pip install -U coverage coveralls zope.testing zope.testrunner
+    - pip install -U -e .[$DEP]
+script:
+    - coverage run -m zope.testrunner --test-path=src
+after_success:
+    - coveralls
+notifications:
+    email: false
 cache: pip
-
-before_cache:
-    - rm -f $HOME/.cache/pip/log/debug.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install:
     - pip install -U coverage coveralls zope.testing zope.testrunner
     - pip install -U -e .[$DEP]
 script:
-    - coverage run -m zope.testrunner --test-path=src
+    - coverage run -m zope.testrunner --auto-color --test-path=src
 after_success:
     - coveralls
 notifications:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,10 +2,12 @@
  CHANGES
 =========
 
-1.0.1 (unreleased)
+1.1.0 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Move more browser dependencies to the ``browser`` extra.
+
+- Begin testing PyPy3 on Travis CI.
 
 
 1.0.0 (2017-04-25)

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,34 @@ def read(*rnames):
 
 version = '1.0.1.dev0'
 
+BROWSER_REQUIRES = [
+    'zope.browser',
+    'zope.browserresource',
+    'zope.publisher >= 4.3.1',
+    'zope.formlib',
+]
+
+TESTS_REQUIRE = BROWSER_REQUIRES + [
+    'zope.app.basicskin >= 4.0.0',
+    'zope.app.http',
+    'zope.app.pagetemplate >= 4.0.0',
+    'zope.app.principalannotation',
+    'zope.app.publication',
+    'zope.app.wsgi',
+
+    'zope.applicationcontrol',
+    'zope.copypastemove',
+    'zope.browser',
+    'zope.browsermenu',
+    'zope.login',
+    'zope.password',
+    'zope.proxy >= 4.2.1',
+    'zope.principalregistry',
+    'zope.securitypolicy',
+    'zope.testbrowser >= 5.2',
+    'zope.testrunner',
+]
+
 setup(
     name='zope.file',
     version=version,
@@ -66,51 +94,29 @@ setup(
         'Topic :: Internet :: WWW/HTTP',
         'Framework :: Zope3',
     ],
-    url='http://cheeseshop.python.org/pypi/zope.file',
+    url='https://github.com/zopefoundation/zope.file',
     license='ZPL 2.1',
     packages=find_packages('src'),
     package_dir={'': 'src'},
     namespace_packages=['zope'],
-    extras_require=dict(
-        test=[
-            'zope.app.basicskin >= 4.0.0',
-            'zope.app.http',
-            'zope.app.pagetemplate >= 4.0.0',
-            'zope.app.principalannotation',
-            'zope.app.publication',
-            'zope.app.wsgi',
-
-            'zope.applicationcontrol',
-            'zope.copypastemove',
-            'zope.browser',
-            'zope.browsermenu',
-            'zope.login',
-            'zope.password',
-            'zope.proxy >= 4.2.1',
-            'zope.principalregistry',
-            'zope.securitypolicy',
-            'zope.testbrowser >= 5.2',
-            'zope.testrunner',
-        ],
-        browser=[
-            'zope.browser',
-        ]
-    ),
+    extras_require={
+        'test': TESTS_REQUIRE,
+        'browser': BROWSER_REQUIRES,
+    },
     install_requires=[
         'setuptools',
         'ZODB',
+        'zope.annotation',
         'zope.component',
         'zope.container',
         'zope.contenttype',
         'zope.event',
         'zope.filerepresentation',
-        'zope.formlib',
         'zope.i18nmessageid',
         'zope.lifecycleevent',
         'zope.interface',
         'zope.location',
-        'zope.mimetype >= 2.2',
-        'zope.publisher >= 4.3.1',
+        'zope.mimetype >= 2.3.0',
         'zope.schema',
         'zope.security >= 4.1.0',
         'zope.size',

--- a/src/zope/file/browser.zcml
+++ b/src/zope/file/browser.zcml
@@ -2,7 +2,7 @@
     xmlns="http://namespaces.zope.org/zope"
     xmlns:browser="http://namespaces.zope.org/browser"
     xmlns:zcml="http://namespaces.zope.org/zcml"
-	zcml:condition="installed zope.browserpage"
+    zcml:condition="installed zope.browserpage"
     i18n_domain="zope.file"
     >
 

--- a/src/zope/file/browser.zcml
+++ b/src/zope/file/browser.zcml
@@ -2,8 +2,11 @@
     xmlns="http://namespaces.zope.org/zope"
     xmlns:browser="http://namespaces.zope.org/browser"
     xmlns:zcml="http://namespaces.zope.org/zcml"
+	zcml:condition="installed zope.browserpage"
     i18n_domain="zope.file"
     >
+
+  <include package="zope.browserpage" file="meta.zcml" />
 
   <browser:view
       for=".interfaces.IFile"

--- a/src/zope/file/configure.zcml
+++ b/src/zope/file/configure.zcml
@@ -1,8 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configure
     xmlns="http://namespaces.zope.org/zope"
+    xmlns:zcml="http://namespaces.zope.org/zcml"
     i18n_domain="zope.file"
     >
+
+  <include package="zope.component" file="meta.zcml" />
+  <include package="zope.security" file="meta.zcml" />
+  <include package="zope.security" file="permissions.zcml" />
 
   <class class=".file.File">
     <require
@@ -48,7 +53,7 @@
            zope.mimetype.interfaces.IContentTypeChangedEvent"
       />
 
-  <class class=".download.DownloadResult">
+  <class class=".download.DownloadResult" zcml:condition="installed zope.publisher">
     <allow interface="zope.publisher.http.IResult"/>
   </class>
 

--- a/src/zope/file/tests/__init__.py
+++ b/src/zope/file/tests/__init__.py
@@ -1,0 +1,8 @@
+import unittest
+
+def skipWithoutZopeFormlib(test):
+    try:
+        from zope import formlib
+    except ImportError:
+        formlib = None
+    return unittest.skipIf(formlib is None, "Need zope.formlib")(test)

--- a/src/zope/file/tests/test_contenttype.py
+++ b/src/zope/file/tests/test_contenttype.py
@@ -5,16 +5,17 @@ import unittest
 from zope import component
 from zope.interface import implementer
 
-from zope.file.contenttype import validateCodecUse
-from zope.file.contenttype import ContentTypeForm
-
 from zope.mimetype.interfaces import IContentTypeEncoded
 from zope.mimetype.interfaces import ICodecPreferredCharset
 
+from zope.file.tests import skipWithoutZopeFormlib
+
+@skipWithoutZopeFormlib
 class TestCodec(unittest.TestCase):
 
     def test_unicode_error_too_short(self):
-
+        from zope.file.contenttype import ContentTypeForm
+        from zope.file.contenttype import validateCodecUse
         class MockFile(object):
             def open(self, _mode):
                 return self
@@ -40,9 +41,11 @@ class TestCodec(unittest.TestCase):
         self.assertEqual("Selected encoding cannot decode document.",
                          errs[0].errors)
 
+@skipWithoutZopeFormlib
 class TestContentTypeForm(unittest.TestCase):
 
     def test_del_charset_no_encoding(self):
+        from zope.file.contenttype import ContentTypeForm
         @implementer(IContentTypeEncoded)
         class MockContext(object):
             def __init__(self):
@@ -61,6 +64,7 @@ class TestContentTypeForm(unittest.TestCase):
         self.assertNotIn('charset', context.parameters)
 
     def test_charset_with_encoding(self):
+        from zope.file.contenttype import ContentTypeForm
         @implementer(IContentTypeEncoded)
         class MockContext(object):
             def __init__(self):

--- a/src/zope/file/tests/test_upload.py
+++ b/src/zope/file/tests/test_upload.py
@@ -5,8 +5,6 @@ import unittest
 from zope import component
 from zope.interface import implementer
 
-from zope.file import upload
-
 from zope.mimetype.interfaces import IContentTypeEncoded
 from zope.mimetype.interfaces import ICharsetCodec
 from zope.mimetype.interfaces import ICodecPreferredCharset
@@ -15,6 +13,8 @@ from zope.mimetype.interfaces import IMimeTypeGetter
 from zope.mimetype.typegetter import smartMimeTypeGuesser
 
 from io import BytesIO
+
+from zope.file.tests import skipWithoutZopeFormlib
 
 @implementer(IContentTypeEncoded)
 class MockContext(object):
@@ -30,11 +30,11 @@ class MockContext(object):
     def close(self):
         pass
 
-
+@skipWithoutZopeFormlib
 class TestFunctions(unittest.TestCase):
 
     def test_name_finder_with_no_filename(self):
-
+        from zope.file import upload
         class MockFile(object):
             pass
 
@@ -42,6 +42,7 @@ class TestFunctions(unittest.TestCase):
 
         self.assertIsNone(res)
 
+@skipWithoutZopeFormlib
 class TestUpdateBlob(unittest.TestCase):
 
     def setUp(self):
@@ -57,13 +58,16 @@ class TestUpdateBlob(unittest.TestCase):
         super(TestUpdateBlob, self).tearDown()
 
     def test_no_mime_type(self):
+        from zope.file import upload
         upload.updateBlob(self.context, self.data)
         self.assertEqual(self.context.mimeType, 'application/octet-stream')
         self.assertEqual(self.context.parameters, {})
 
+@skipWithoutZopeFormlib
 class TestReupload(unittest.TestCase):
 
     def test_different_codec(self):
+        from zope.file import upload
 
         class MockCodec(object):
             name = 'TestContentTypeForm'

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,26 @@
 [tox]
 envlist =
-    py27, pypy, py34, py35, py36
+    py27,py34,py35,py36,pypy,pypy3,coverage,minimal
 
 [testenv]
 commands =
     zope-testrunner --test-path=src []
 deps =
     .[test]
+
+[testenv:minimal]
+deps =
+    .
+    zope.testrunner
+    zope.testing
+
+[testenv:coverage]
+usedevelop = true
+basepython =
+    python2.7
+commands =
+    coverage run -m zope.testrunner --test-path=src []
+    coverage report --fail-under=98
+deps =
+    {[testenv]deps}
+    coverage


### PR DESCRIPTION
And add test environments to be sure we can actually run without it.

It turns out we couldn't.

WIP because zope.container has a hard dependency on zope.publisher (that I'd like to try to break), so it's still getting pulled in even in the minimal environments.

Also update PyPy on Travis CI.